### PR TITLE
fix UFO font export

### DIFF
--- a/ObjectWrapper/GlyphsApp/__init__.py
+++ b/ObjectWrapper/GlyphsApp/__init__.py
@@ -5837,7 +5837,7 @@ def __Font_Export__(self, Format=OTF, Instances=None, FontPath=None, AutoHint=Tr
 		ufoWriter.setConvertNames_(UseProductionNames)
 		ufoWriter.setDecomposeSmartStuff_(DecomposeSmartStuff)
 		ufoWriter.setExportOptions_({"SeletedMasterIndexes": NSIndexSet.indexSetWithIndexesInRange_(NSRange(0, len(Font.masters)))})
-		result = Exporter.exportFont_toDirectory_error_(Font, NSURL.fileURLWithPath_(FontPath), None)
+		result = ufoWriter.writeFont_toURL_error_(Font, NSURL.fileURLWithPath_(FontPath), None)
 		return result
 	else:
 		if not Instances:


### PR DESCRIPTION
This PR fixes `local variable 'Exporter' referenced before assignment` issue for UFO font export.

<img width="624" alt="Screen Shot 2021-12-05 at 19 03 51" src="https://user-images.githubusercontent.com/6161120/144754481-7fd8bd52-b780-43f5-bb21-ec3d3b3ba9a2.png">
