### PR TITLE
add sample plugin with window

### DIFF
--- a/Xcode Samples/Plugin With Window/Plugin With Window.xcodeproj/project.pbxproj
+++ b/Xcode Samples/Plugin With Window/Plugin With Window.xcodeproj/project.pbxproj
@@ -1,0 +1,332 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4DED2B0E27C802AE002BFFB7 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4DED2B0D27C802AE002BFFB7 /* Cocoa.framework */; };
+		4DED2B1227C802AE002BFFB7 /* Plugin_With_Window.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DED2B1127C802AE002BFFB7 /* Plugin_With_Window.m */; };
+		4DED2B1427C802AE002BFFB7 /* GlyphsCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4DED2B1327C802AE002BFFB7 /* GlyphsCore.framework */; };
+		4DED2B1627C802AE002BFFB7 /* Plugin With Window-Prefix.pch in Resources */ = {isa = PBXBuildFile; fileRef = 4DED2B1527C802AE002BFFB7 /* Plugin With Window-Prefix.pch */; };
+		4DED2B1E27C8038A002BFFB7 /* MyPluginWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4DED2B1D27C8038A002BFFB7 /* MyPluginWindow.xib */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		4DED2B0A27C802AE002BFFB7 /* Plugin With Window.glyphsPlugin */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Plugin With Window.glyphsPlugin"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4DED2B0D27C802AE002BFFB7 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		4DED2B1027C802AE002BFFB7 /* Plugin_With_Window.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Plugin_With_Window.h; sourceTree = "<group>"; };
+		4DED2B1127C802AE002BFFB7 /* Plugin_With_Window.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Plugin_With_Window.m; sourceTree = "<group>"; };
+		4DED2B1327C802AE002BFFB7 /* GlyphsCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GlyphsCore.framework; path = "/Applications/Glyphs 3.app/Contents/Frameworks/GlyphsCore.framework"; sourceTree = "<absolute>"; };
+		4DED2B1527C802AE002BFFB7 /* Plugin With Window-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Plugin With Window-Prefix.pch"; sourceTree = "<group>"; };
+		4DED2B1727C802AE002BFFB7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4DED2B1D27C8038A002BFFB7 /* MyPluginWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MyPluginWindow.xib; sourceTree = "<group>"; };
+		4DED2BA127C812FF002BFFB7 /* GlyphsCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GlyphsCore.framework; path = "../../../../../Applications/Glyphs 3.app/Contents/Frameworks/GlyphsCore.framework"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		4DED2B0727C802AE002BFFB7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4DED2B1427C802AE002BFFB7 /* GlyphsCore.framework in Frameworks */,
+				4DED2B0E27C802AE002BFFB7 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		4DED2B0127C802AE002BFFB7 = {
+			isa = PBXGroup;
+			children = (
+				4DED2B0F27C802AE002BFFB7 /* Plugin With Window */,
+				4DED2B0C27C802AE002BFFB7 /* Frameworks */,
+				4DED2B0B27C802AE002BFFB7 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		4DED2B0B27C802AE002BFFB7 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				4DED2B0A27C802AE002BFFB7 /* Plugin With Window.glyphsPlugin */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		4DED2B0C27C802AE002BFFB7 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				4DED2BA127C812FF002BFFB7 /* GlyphsCore.framework */,
+				4DED2B0D27C802AE002BFFB7 /* Cocoa.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		4DED2B0F27C802AE002BFFB7 /* Plugin With Window */ = {
+			isa = PBXGroup;
+			children = (
+				4DED2B1027C802AE002BFFB7 /* Plugin_With_Window.h */,
+				4DED2B1127C802AE002BFFB7 /* Plugin_With_Window.m */,
+				4DED2B1D27C8038A002BFFB7 /* MyPluginWindow.xib */,
+				4DED2B1327C802AE002BFFB7 /* GlyphsCore.framework */,
+				4DED2B1527C802AE002BFFB7 /* Plugin With Window-Prefix.pch */,
+				4DED2B1727C802AE002BFFB7 /* Info.plist */,
+			);
+			path = "Plugin With Window";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		4DED2B0927C802AE002BFFB7 /* Plugin With Window */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4DED2B1A27C802AE002BFFB7 /* Build configuration list for PBXNativeTarget "Plugin With Window" */;
+			buildPhases = (
+				4DED2B0627C802AE002BFFB7 /* Sources */,
+				4DED2B0727C802AE002BFFB7 /* Frameworks */,
+				4DED2B0827C802AE002BFFB7 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Plugin With Window";
+			productName = "Plugin With Window";
+			productReference = 4DED2B0A27C802AE002BFFB7 /* Plugin With Window.glyphsPlugin */;
+			productType = "com.apple.product-type.bundle";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		4DED2B0227C802AE002BFFB7 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastUpgradeCheck = 1320;
+				TargetAttributes = {
+					4DED2B0927C802AE002BFFB7 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+				};
+			};
+			buildConfigurationList = 4DED2B0527C802AE002BFFB7 /* Build configuration list for PBXProject "Plugin With Window" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 4DED2B0127C802AE002BFFB7;
+			productRefGroup = 4DED2B0B27C802AE002BFFB7 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				4DED2B0927C802AE002BFFB7 /* Plugin With Window */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		4DED2B0827C802AE002BFFB7 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4DED2B1E27C8038A002BFFB7 /* MyPluginWindow.xib in Resources */,
+				4DED2B1627C802AE002BFFB7 /* Plugin With Window-Prefix.pch in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		4DED2B0627C802AE002BFFB7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4DED2B1227C802AE002BFFB7 /* Plugin_With_Window.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		4DED2B1827C802AE002BFFB7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		4DED2B1927C802AE002BFFB7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		4DED2B1B27C802AE002BFFB7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEPLOYMENT_LOCATION = YES;
+				DEVELOPMENT_TEAM = 79B65AX6G6;
+				DSTROOT = "$(USER_LIBRARY_DIR)/Application Support/Glyphs 3/Plugins";
+				FRAMEWORK_SEARCH_PATHS = "\"$(SYSTEM_APPS_DIR)/Glyphs 3.app/Contents/Frameworks\"";
+				GCC_PREFIX_HEADER = "Plugin With Window/Plugin With Window-Prefix.pch";
+				GENERATE_INFOPLIST_FILE = YES;
+				INSTALL_PATH = /;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Glyphs.Plugin-With-Window";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				WRAPPER_EXTENSION = glyphsPlugin;
+			};
+			name = Debug;
+		};
+		4DED2B1C27C802AE002BFFB7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 79B65AX6G6;
+				FRAMEWORK_SEARCH_PATHS = "\"$(SYSTEM_APPS_DIR)/Glyphs 3.app/Contents/Frameworks\"";
+				GCC_PREFIX_HEADER = "Plugin With Window/Plugin With Window-Prefix.pch";
+				GENERATE_INFOPLIST_FILE = YES;
+				INSTALL_PATH = /;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Glyphs.Plugin-With-Window";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				WRAPPER_EXTENSION = glyphsPlugin;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		4DED2B0527C802AE002BFFB7 /* Build configuration list for PBXProject "Plugin With Window" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4DED2B1827C802AE002BFFB7 /* Debug */,
+				4DED2B1927C802AE002BFFB7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4DED2B1A27C802AE002BFFB7 /* Build configuration list for PBXNativeTarget "Plugin With Window" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4DED2B1B27C802AE002BFFB7 /* Debug */,
+				4DED2B1C27C802AE002BFFB7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 4DED2B0227C802AE002BFFB7 /* Project object */;
+}

--- a/Xcode Samples/Plugin With Window/Plugin With Window.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Xcode Samples/Plugin With Window/Plugin With Window.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Xcode Samples/Plugin With Window/Plugin With Window.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Xcode Samples/Plugin With Window/Plugin With Window.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Xcode Samples/Plugin With Window/Plugin With Window.xcodeproj/xcshareddata/xcschemes/Plugin With Window.xcscheme
+++ b/Xcode Samples/Plugin With Window/Plugin With Window.xcodeproj/xcshareddata/xcschemes/Plugin With Window.xcscheme
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1320"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4DED2B0927C802AE002BFFB7"
+               BuildableName = "Plugin With Window.glyphsPlugin"
+               BlueprintName = "Plugin With Window"
+               ReferencedContainer = "container:Plugin With Window.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      disableMainThreadChecker = "YES"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         FilePath = "/Applications/Glyphs 3.app/Contents/MacOS/Glyphs 3">
+      </PathRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4DED2B0927C802AE002BFFB7"
+            BuildableName = "Plugin With Window.glyphsPlugin"
+            BlueprintName = "Plugin With Window"
+            ReferencedContainer = "container:Plugin With Window.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Xcode Samples/Plugin With Window/Plugin With Window/Info.plist
+++ b/Xcode Samples/Plugin With Window/Plugin With Window/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrincipalClass</key>
+	<string>Plugin_With_Window</string>
+</dict>
+</plist>

--- a/Xcode Samples/Plugin With Window/Plugin With Window/MyPluginWindow.xib
+++ b/Xcode Samples/Plugin With Window/Plugin With Window/MyPluginWindow.xib
@@ -13,12 +13,12 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="480" height="270"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
-            <view key="contentView" wantsLayer="YES" misplaced="YES" id="EiT-Mj-1SZ">
+            <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="440" height="71"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>

--- a/Xcode Samples/Plugin With Window/Plugin With Window/MyPluginWindow.xib
+++ b/Xcode Samples/Plugin With Window/Plugin With Window/MyPluginWindow.xib
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="Plugin_With_Window">
+            <connections>
+                <outlet property="fontNameLabel" destination="5LS-iz-okA" id="FTt-lA-0ki"/>
+                <outlet property="window" destination="QvC-M9-y7g" id="zeT-oI-P6k"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="196" y="240" width="480" height="270"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
+            <view key="contentView" wantsLayer="YES" misplaced="YES" id="EiT-Mj-1SZ">
+                <rect key="frame" x="0.0" y="0.0" width="440" height="71"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9oa-mU-BXh">
+                        <rect key="frame" x="18" y="20" width="404" height="31"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="400" id="6u4-id-J3t"/>
+                        </constraints>
+                        <textFieldCell key="cell" lineBreakMode="clipping" title="Label" id="5LS-iz-okA">
+                            <font key="font" textStyle="largeTitle" name=".SFNS-Regular"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="9oa-mU-BXh" firstAttribute="top" secondItem="EiT-Mj-1SZ" secondAttribute="top" constant="20" symbolic="YES" id="HYe-sm-vg5"/>
+                    <constraint firstAttribute="trailing" secondItem="9oa-mU-BXh" secondAttribute="trailing" constant="20" symbolic="YES" id="hcF-WF-01a"/>
+                    <constraint firstItem="9oa-mU-BXh" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="20" symbolic="YES" id="uwU-es-RPy"/>
+                    <constraint firstAttribute="bottom" secondItem="9oa-mU-BXh" secondAttribute="bottom" constant="20" symbolic="YES" id="yfY-yc-sBN"/>
+                </constraints>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="-2" id="Xrl-gQ-1TS"/>
+            </connections>
+            <point key="canvasLocation" x="139" y="144"/>
+        </window>
+    </objects>
+</document>

--- a/Xcode Samples/Plugin With Window/Plugin With Window/Plugin With Window-Prefix.pch
+++ b/Xcode Samples/Plugin With Window/Plugin With Window/Plugin With Window-Prefix.pch
@@ -1,0 +1,5 @@
+#if DEBUG
+#define	GSLog(args...)			(void)printf("%i %s: %s\n", __LINE__, __PRETTY_FUNCTION__, [[NSString stringWithFormat:args] UTF8String])
+#else
+#define	GSLog(args...)			// stubbed out
+#endif

--- a/Xcode Samples/Plugin With Window/Plugin With Window/Plugin_With_Window.h
+++ b/Xcode Samples/Plugin With Window/Plugin With Window/Plugin_With_Window.h
@@ -1,0 +1,17 @@
+//
+//  Plugin_With_Window.h
+//  Plugin With Window
+//
+//  Created by Mark Frömberg on 24.02.22.
+//
+//
+
+#import <Cocoa/Cocoa.h>
+
+#import <GlyphsCore/GlyphsPluginProtocol.h>
+
+@interface Plugin_With_Window : NSWindowController <GlyphsPlugin>
+
+@property (strong) IBOutlet NSTextFieldCell *fontNameLabel;
+
+@end

--- a/Xcode Samples/Plugin With Window/Plugin With Window/Plugin_With_Window.m
+++ b/Xcode Samples/Plugin With Window/Plugin With Window/Plugin_With_Window.m
@@ -90,9 +90,11 @@ static NSString * const showPluginWindowKey = @"XYShowMyPluginWindow"; /// Use y
 - (void)_updateDoc {
 	NSApplication<GSApplicationPluginProtocol> *app = NSApp;
 	GSDocument *Doc = [app currentFontDocument];
+	if (Doc.font == _currentFont) return;
 	[self setCurrentFont:Doc.font];
 	self.fontNameLabel.stringValue = _currentFont.fontName;
 	self.window.title = [NSString stringWithFormat:@"%@: %@", self.title, _currentFont.fontName];
+	/// Optionally call update methods of your plugin here.
 }
 
 
@@ -137,7 +139,6 @@ static NSString * const showPluginWindowKey = @"XYShowMyPluginWindow"; /// Use y
 - (void)setCurrentFont:(GSFont *)currentFont {
 	if (_currentFont != currentFont) {
 		_currentFont = currentFont;
-		/// Optionally call update methods of your plugin here.
 	}
 }
 

--- a/Xcode Samples/Plugin With Window/Plugin With Window/Plugin_With_Window.m
+++ b/Xcode Samples/Plugin With Window/Plugin With Window/Plugin_With_Window.m
@@ -1,0 +1,154 @@
+//
+//  Plugin_With_Window.m
+//  Plugin With Window
+//
+//  Created by Mark Frömberg on 24.02.22.
+//
+//
+
+#import <GlyphsCore/GSFont.h>
+#import <GlyphsCore/GSWindowControllerProtocol.h>
+#import "Plugin_With_Window.h"
+
+static void *DocumentBindingContext = (void *)@"Document";
+static NSString * const showPluginWindowKey = @"XYShowMyPluginWindow"; /// Use your own prefix instead of `XY`
+
+@protocol GSApplicationPluginProtocol <NSObject>
+
+- (NSArray *)fontDocuments;
+
+- (GSDocument *)currentFontDocument;
+
+@end
+
+@interface GSDocument : NSObject
+
+- (GSFont *)font;
+
+- (NSWindowController<GSWindowControllerProtocol> *)windowController;
+
+@end
+
+@implementation Plugin_With_Window {
+	BOOL _hasRegisteredObservers;
+	GSFont *__weak _currentFont;
+	NSViewController<GSGlyphEditViewControllerProtocol> *__weak _currentEditViewController;
+}
+
+- (NSUInteger)interfaceVersion {
+	// Distinguishes the API verison the plugin was built for. Return 1.
+	return 1;
+}
+
+- (instancetype)init {
+	self = [super initWithWindowNibName:@"MyPluginWindow"];
+	if (self) {
+		[self window];
+	}
+	return self;
+}
+
+- (NSString *)title {
+	return @"Plugin With Window";
+}
+
+- (void)loadPlugin {
+	NSMenu *mainMenu = [[NSApplication sharedApplication] mainMenu];
+	NSMenuItem *newMenuItem = [[NSMenuItem alloc] initWithTitle:[self title] action:@selector(showMyPluginWindow:) keyEquivalent:@""];
+	[newMenuItem setTarget:self];
+	NSUInteger newItemIndex = 0;
+	NSMenu *submenu = [[mainMenu itemWithTag:17] submenu];
+	BOOL foundFirstSeparator = NO;
+	for (NSMenuItem *item in [submenu itemArray]) {
+		if ([item isSeparatorItem]) {
+			if (!foundFirstSeparator) {
+				foundFirstSeparator = YES;
+			} else {
+				break;
+			}
+		}
+		newItemIndex++;
+	}
+	
+	[submenu insertItem:newMenuItem atIndex:newItemIndex];
+	
+	if ([[NSUserDefaults standardUserDefaults] boolForKey:showPluginWindowKey]) {
+		[self showMyPluginWindow:nil];
+	}
+}
+
+- (void)awakeFromNib {
+	self.fontNameLabel.stringValue = @"No Font Open";
+	self.window.title = [NSString stringWithFormat:@"%@", self.title];
+	self.window.level = NSFloatingWindowLevel;
+}
+
+- (void)dealloc {
+	[self removeNotifications];
+}
+
+- (void)_updateDoc {
+	NSApplication<GSApplicationPluginProtocol> *app = NSApp;
+	GSDocument *Doc = [app currentFontDocument];
+	[self setCurrentFont:Doc.font];
+	self.fontNameLabel.stringValue = _currentFont.fontName;
+	self.window.title = [NSString stringWithFormat:@"%@: %@", self.title, _currentFont.fontName];
+}
+
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+					  ofObject:(id)object
+						change:(NSDictionary *)change
+					   context:(void *)context {
+	
+	if (context == DocumentBindingContext) {
+		[self performSelector:@selector(_updateDoc) withObject:nil afterDelay:0.0];
+	}
+}
+
+- (void)setUpNotifications {
+	if (!_hasRegisteredObservers) {
+		[NSApp addObserver:self forKeyPath:@"mainWindow.windowController.document" options:1 context:DocumentBindingContext];
+		_hasRegisteredObservers = YES;
+	}
+}
+
+- (void)removeNotifications {
+	if (_hasRegisteredObservers) {
+		[NSApp removeObserver:self forKeyPath:@"mainWindow.windowController.document"];
+		_hasRegisteredObservers = NO;
+	}
+}
+
+- (IBAction)showMyPluginWindow:(id)sender {
+	if ([[self window] isVisible]) {
+		[[NSUserDefaults standardUserDefaults] setBool:NO forKey:showPluginWindowKey];
+		[self.window orderOut:sender];
+		[self removeNotifications];
+	}
+	else {
+		[[NSUserDefaults standardUserDefaults] setBool:YES forKey:showPluginWindowKey];
+		[self.window makeKeyAndOrderFront:sender];
+		[self setUpNotifications];
+	}
+}
+
+
+- (void)setCurrentFont:(GSFont *)currentFont {
+	if (_currentFont != currentFont) {
+		_currentFont = currentFont;
+		/// Optionally call update methods of your plugin here.
+	}
+}
+
+#pragma mark window delegate
+
+- (BOOL)windowShouldClose:(id)window {
+	if (self.window == window) {
+		[[NSUserDefaults standardUserDefaults] setBool:NO forKey:showPluginWindowKey];
+		[self removeNotifications];
+	}
+	return YES;
+}
+
+@end


### PR DESCRIPTION
@schriftgestalt 

Here’s my draft of the boilerplate. There’s one thing still that breaks my head: I cannot make the window **not** appear on app launch. It always shows when the plugin isn’t even yet active. I tried all kinds of things with the window, but they all make no sense to me. I bet you know it right away.

Once it’s approved by you, I can also add some comments, as e.g. the `@interface GSDocument : NSObject` and `@protocol GSApplicationPluginProtocol <NSObject>` additions seem to be necessary in order to make the compiler shut up about missing declatations.