### PR TITLE
explicit imports from AppKit

### DIFF
--- a/ObjectWrapper/Unit Test/UnitTest.py
+++ b/ObjectWrapper/Unit Test/UnitTest.py
@@ -14,7 +14,21 @@ from GlyphsApp import *
 import os, time, sys, datetime
 import objc
 import copy
-from AppKit import *
+
+from AppKit import \
+NSAffineTransform, \
+NSArray, \
+NSBezierPath, \
+NSColor, \
+NSDate, \
+NSDictionary, \
+NSImage, \
+NSMenuItem, \
+NSMenuItem, \
+NSNull, \
+NSNumber, \
+NSPoint, \
+NSRect
 
 if sys.version_info[0] == 3:
 	unicode = str


### PR DESCRIPTION
`from AppKit import *` is bad practice and fails with the Glyphs Python for some reason ("ModuleNotFoundError: No module named 'AppKit._AppKit.ContactsPersistence'; 'AppKit._AppKit' is not a package"