### PR TITLE
Add a ghost hint to the reference files

### DIFF
--- a/GlyphsFileFormat/GlyphsFileFormatv3.glyphs
+++ b/GlyphsFileFormat/GlyphsFileFormatv3.glyphs
@@ -1207,6 +1207,14 @@ glyphname = _part.test;
 lastChange = "2023-02-25 14:14:38 +0000";
 layers = (
 {
+hints = (
+{
+horizontal = 1;
+origin = (0,3);
+target = down;
+type = TopGhost;
+}
+);
 layerId = m01;
 partSelection = {
 Width = 1;

--- a/GlyphsFileFormat/GlyphsFileFormatv3.glyphspackage/glyphs/_part.test.glyph
+++ b/GlyphsFileFormat/GlyphsFileFormatv3.glyphspackage/glyphs/_part.test.glyph
@@ -3,6 +3,14 @@ export = 0;
 glyphname = _part.test;
 layers = (
 {
+hints = (
+{
+horizontal = 1;
+origin = (0,3);
+target = down;
+type = TopGhost;
+}
+);
 layerId = m01;
 partSelection = {
 Width = 1;

--- a/GlyphsFileFormat/GlyphsFileFormatv3.md
+++ b/GlyphsFileFormat/GlyphsFileFormatv3.md
@@ -146,15 +146,15 @@ The property list file contains a dictionary with the following structure.
             * horizontal `int`: If set, the hint is horizontal and vertical otherwise
             * type `string`: The type of the hint. Possible value are: Tag, TopGhost, Stem, BottomGhost, Flex, TTAnchor, TTStem, TTAlign, TTInterpolate, TTDiagonal, TTDelta, Corner, Cap, Brush, Line, Auto
                 If there is no type, it defaults to Stem, or Ghost if `target` is not set
-            * origin `tuple`: 
+            * origin `tuple|string`:
                 - (pathIndex,nodeIndex) Most likely case, points to a real node
                 - (pathIndex,nodeIndex,inflectionIndex) Points to an inflection. The first two numbers point to the on-curve node that finishes the curve segment. The third item indicates the index of the inflection. Most likely `0`. 
                 - (pathIndex1,nodeIndex1,pathIndex2,nodeIndex2) Points to a intersection of two segments. The nodes are the ones that finish the segment. 
-                - (sideBearingFlag) `lsb|rsb` To attache a hint to the side-bearings
-            * target `tuple`: 
+                - sideBearingFlag `lsb|rsb` To attache a hint to the side-bearings
+            * target `tuple|string`:
                 For details see `origin` above. 
                 additional:
-                - (ghostDirection) `up|down`
+                - ghostDirection `up|down`
             * other1 `tuple`: 
                 For TT Institutions that need more than two nodes (Interpolation, Diagonal)
                 For details see `origin` above. 


### PR DESCRIPTION
As part of an [ongoing pull request](https://github.com/googlefonts/glyphsLib/pull/869) in `glyphsLib`, it would be helpful to have it recorded in the reference files how hints with string `target`'s are supposed to be represented.