### PR TITLE
Add delegate comments

### DIFF
--- a/Python Samples/Plugin With Window/Plugin With Window.glyphsPlugin/Contents/Resources/plugin.py
+++ b/Python Samples/Plugin With Window/Plugin With Window.glyphsPlugin/Contents/Resources/plugin.py
@@ -34,6 +34,7 @@ class PluginWithWindow(GeneralPlugin):
 			})
 		self.loadNib("MyPluginWindow", __file__) # Load .nib file next to plugin.py
 		self.window.setTitle_(self.name)
+		# self.window._window.setDelegate_(self) # If using a vanilla window, set delegate here.
 		self.window.setFrameAutosaveName_(self.windowName)
 		self.fontNameLabel.setStringValue_("No Font Open")
 
@@ -76,6 +77,7 @@ class PluginWithWindow(GeneralPlugin):
 		"""Please leave this method unchanged"""
 		return __file__
 
+	# Window Delegate Method
 	def windowShouldClose_(self, window):
 		Glyphs.removeCallback(self.update) # Remove callbacks when the window is closed
 		return True


### PR DESCRIPTION
When using a vanilla window instead of a xib, the delegate must be set in order for the `windowShouldClose_` to be called.

If it is not called, the callbacks are not removed and will cause a crash.