### PR TITLE
Change default value of 'closed' to match Glyphs 3 behaviour

### DIFF
--- a/GlyphsFileFormat/GlyphsFileFormatv2.md
+++ b/GlyphsFileFormat/GlyphsFileFormatv2.md
@@ -138,7 +138,7 @@ The XML file contains a dictionary with the following structure. The elements wi
         * widthMetricsKey `string`
         * name `string`: The name of the layer. Only stored for none master layers (this is changed in 2.3, before the master names where stored)
         * paths `list`
-            * closed `bool`: Always set to `1`. If not set, the key is not present at all.
+            * closed `bool`: Always set to `0`, otherwise omit the key.
             * nodes `list`: One entry per node. Format: `X Y TYPE [SMOOTH]`, where X and Y are the coordinates as float, and TYPE is either `LINE`, `CURVE` or `OFFCURVE`. After `LINE` and `CURVE`, you can additionally add a `SMOOTH`.
         * userDate `dict`: A dict with user defined structure
         * vertWidth `float`: Only stored if other than the default (ascender+descender)

--- a/GlyphsFileFormat/GlyphsFileFormatv3.md
+++ b/GlyphsFileFormat/GlyphsFileFormatv3.md
@@ -176,7 +176,7 @@ The property list file contains a dictionary with the following structure.
         * shapes `list>dict`: Can be paths or components
             * path:
                 * attr: `dict`: see [Attributes](*attributes)
-                * closed `bool`: Always set to `1`, otherwise omit the key
+                * closed `bool`: Always set to `0`, otherwise omit the key
                 * nodes `tuple`: `(X,Y,TYPE[SMOOTH],{user:data})`, where X and Y are the coordinates as float, and TYPE is either `l`, `c`, `o`, `q`. when the on-curve node is smooth, add an `s`.
                 when the node has usedData store it as fourth element. Remove all newlines and extra spaces.
             * component:


### PR DESCRIPTION
Hi Georg!

We found that omitting the `closed` property causes Glyphs 3 to assume a path is closed; can you confirm that this is what Glyphs expects in all scenarios?

(if the Glyphs 2 file format behaves the same way, then am happy to include that change in this mini-PR too 🤜🤛)